### PR TITLE
Small improvement: BOHB reader + Fix error in fanova

### DIFF
--- a/deepcave/plugins/fanova.py
+++ b/deepcave/plugins/fanova.py
@@ -4,6 +4,7 @@ from dash import dcc, html
 from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 import plotly.graph_objs as go
+from ast import literal_eval
 
 import pandas as pd
 import numpy as np
@@ -155,6 +156,7 @@ class fANOVA(StaticPlugin):
         # Collect data
         data = {}
         for budget, importance_dict in outputs.items():
+            budget = literal_eval(budget) if isinstance(budget, str) else budget
             budget = convert_type(budget)
 
             if budget not in inputs["budgets"]["value"]:

--- a/deepcave/runs/converters/bohb.py
+++ b/deepcave/runs/converters/bohb.py
@@ -51,6 +51,7 @@ class BOHB(Converter):
 
         from hpbandster.core.result import logged_results_to_HBS_result
         bohb = logged_results_to_HBS_result(base)
+        config_mapping = bohb.get_id2config_mapping()
 
         first_starttime = None
         for bohb_run in bohb.get_all_runs():
@@ -67,13 +68,16 @@ class BOHB(Converter):
 
             cost = bohb_run.loss
             budget = bohb_run.budget
-            config = bohb_run.info["config"]
-            # Convert str to dict
-            config = json.loads(config)
+
+            if bohb_run.info is None:
+                status = 'CRASHED'
+            else:
+                status = bohb_run.info["state"]
+
+            config = config_mapping[bohb_run.config_id]['config']
 
             origin = None
             additional = {}
-            status = bohb_run.info["state"]
 
             # QUEUED, RUNNING, CRASHED, REVIEW, TERMINATED, COMPLETED, SUCCESS
             if "SUCCESS" in status or "TERMINATED" in status or "COMPLETED" in status:


### PR DESCRIPTION
1 part) 
I have often encountered the following error with python3.9 in the fanova plugin:

```ValueError: invalid literal for int() with base 10: '200.0'```  

It has occurred when the `int` function is called with a string: 
```int('200.0')```

The `ast` function solves that. 


Second thing: 
- If a `BOHB` run has crashed, it might have no `info` field. (Or at least that happened to me). 
- Also, we can remove the configuration loading with `json` when retrieving the config from `BOHB's configuration mapping`