### PR TITLE
fix: Put in missing "q" values into configspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.1.1
+
+## Bug-Fixes
+- Put in missing "q" values into configspaces to allow using newer ConfigSpace versions. 
+
 # Version 1.1
 
 ## Converters

--- a/logs/BOHB/bohb_1/configspace.json
+++ b/logs/BOHB/bohb_1/configspace.json
@@ -6,7 +6,8 @@
       "log": true,
       "lower": 16,
       "upper": 128,
-      "default": 64
+      "default": 64,
+      "q": null
     },
     {
       "name": "dropout",
@@ -15,6 +16,7 @@
       "lower": 0.0,
       "upper": 0.5,
       "default": 0.0
+      "q": null
     },
     {
       "name": "kernel_size",
@@ -23,6 +25,7 @@
       "lower": 2,
       "upper": 16,
       "default": 8
+      "q": null
     },
     {
       "name": "l2_decay",
@@ -30,7 +33,8 @@
       "log": true,
       "lower": 1e-09,
       "upper": 0.0001,
-      "default": 1e-05
+      "default": 1e-05,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -38,7 +42,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.01,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "lr_scheduler",
@@ -56,7 +61,8 @@
       "log": false,
       "lower": 50,
       "upper": 150,
-      "default": 100
+      "default": 100,
+      "q": null
     },
     {
       "name": "num_channels",
@@ -64,7 +70,8 @@
       "log": true,
       "lower": 32,
       "upper": 512,
-      "default": 64
+      "default": 64,
+      "q": null
     },
     {
       "name": "num_levels",
@@ -72,7 +79,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 3
+      "default": 3,
+      "q": null
     },
     {
       "name": "use_augmentation",
@@ -90,7 +98,8 @@
       "log": true,
       "lower": 1e-09,
       "upper": 0.0001,
-      "default": 1e-05
+      "default": 1e-05,
+      "q": null
     },
     {
       "name": "lr_scheduler_tmult",
@@ -98,7 +107,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 1
+      "default": 1,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/BOHB/bohb_1/configspace.json
+++ b/logs/BOHB/bohb_1/configspace.json
@@ -15,7 +15,7 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.5,
-      "default": 0.0
+      "default": 0.0,
       "q": null
     },
     {
@@ -24,7 +24,7 @@
       "log": true,
       "lower": 2,
       "upper": 16,
-      "default": 8
+      "default": 8,
       "q": null
     },
     {

--- a/logs/BOHB/bohb_2/configspace.json
+++ b/logs/BOHB/bohb_2/configspace.json
@@ -6,7 +6,8 @@
       "log": true,
       "lower": 16,
       "upper": 128,
-      "default": 64
+      "default": 64,
+      "q": null
     },
     {
       "name": "dropout",
@@ -14,7 +15,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.5,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "kernel_size",
@@ -22,7 +24,8 @@
       "log": true,
       "lower": 2,
       "upper": 16,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "l2_decay",
@@ -30,7 +33,8 @@
       "log": true,
       "lower": 1e-09,
       "upper": 0.0001,
-      "default": 1e-05
+      "default": 1e-05,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -38,7 +42,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.01,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "lr_scheduler",
@@ -56,7 +61,8 @@
       "log": false,
       "lower": 50,
       "upper": 150,
-      "default": 100
+      "default": 100,
+      "q": null
     },
     {
       "name": "num_channels",
@@ -64,7 +70,8 @@
       "log": true,
       "lower": 32,
       "upper": 512,
-      "default": 64
+      "default": 64,
+      "q": null
     },
     {
       "name": "num_levels",
@@ -72,7 +79,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 3
+      "default": 3,
+      "q": null
     },
     {
       "name": "use_augmentation",
@@ -90,7 +98,8 @@
       "log": true,
       "lower": 1e-09,
       "upper": 0.0001,
-      "default": 1e-05
+      "default": 1e-05,
+      "q": null
     },
     {
       "name": "lr_scheduler_tmult",
@@ -98,7 +107,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 1
+      "default": 1,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/DeepCAVE/digits_sklearn/run_1/configspace.json
+++ b/logs/DeepCAVE/digits_sklearn/run_1/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 100,
-      "default": 50
+      "default": 50,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.1,
-      "default": 0.0031622777
+      "default": 0.0031622777,
+      "q": null
     },
     {
       "name": "num_neurons_layer1",
@@ -33,7 +35,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "num_neurons_layer2",
@@ -41,7 +44,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "solver",

--- a/logs/DeepCAVE/digits_sklearn/run_2/configspace.json
+++ b/logs/DeepCAVE/digits_sklearn/run_2/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 100,
-      "default": 50
+      "default": 50,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.1,
-      "default": 0.0031622777
+      "default": 0.0031622777,
+      "q": null
     },
     {
       "name": "num_neurons_layer1",
@@ -33,7 +35,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "num_neurons_layer2",
@@ -41,7 +44,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "solver",

--- a/logs/DeepCAVE/digits_sklearn/run_3/configspace.json
+++ b/logs/DeepCAVE/digits_sklearn/run_3/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 100,
-      "default": 50
+      "default": 50,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.1,
-      "default": 0.0031622777
+      "default": 0.0031622777,
+      "q": null
     },
     {
       "name": "num_neurons_layer1",
@@ -33,7 +35,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "num_neurons_layer2",
@@ -41,7 +44,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "solver",

--- a/logs/DeepCAVE/minimal/run_1/configspace.json
+++ b/logs/DeepCAVE/minimal/run_1/configspace.json
@@ -6,7 +6,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "beta",
@@ -14,7 +15,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "gamma",
@@ -22,7 +24,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     }
   ],
   "conditions": [],

--- a/logs/DeepCAVE/minimal/run_2/configspace.json
+++ b/logs/DeepCAVE/minimal/run_2/configspace.json
@@ -6,7 +6,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "beta",
@@ -14,7 +15,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "gamma",
@@ -22,7 +24,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     }
   ],
   "conditions": [],

--- a/logs/DeepCAVE/minimal/run_3/configspace.json
+++ b/logs/DeepCAVE/minimal/run_3/configspace.json
@@ -6,7 +6,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "beta",
@@ -14,7 +15,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "gamma",
@@ -22,7 +24,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 1.0,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     }
   ],
   "conditions": [],

--- a/logs/DeepCAVE/mnist_pytorch/run_1/configspace.json
+++ b/logs/DeepCAVE/mnist_pytorch/run_1/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 16,
       "upper": 256,
-      "default": 136
+      "default": 136,
+      "q": null
     },
     {
       "name": "dropout_rate",
@@ -25,7 +26,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 0.9,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -33,7 +35,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.1,
-      "default": 0.0031622777
+      "default": 0.0031622777,
+      "q": null
     },
     {
       "name": "model",
@@ -51,7 +54,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "num_neurons_layer2",
@@ -59,7 +63,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/DeepCAVE/mnist_pytorch/run_2/configspace.json
+++ b/logs/DeepCAVE/mnist_pytorch/run_2/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 16,
       "upper": 256,
-      "default": 136
+      "default": 136,
+      "q": null
     },
     {
       "name": "dropout_rate",
@@ -25,7 +26,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 0.9,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -33,7 +35,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.1,
-      "default": 0.0031622777
+      "default": 0.0031622777,
+      "q": null
     },
     {
       "name": "model",
@@ -51,7 +54,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "num_neurons_layer2",
@@ -59,7 +63,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/DeepCAVE/mnist_pytorch/run_3/configspace.json
+++ b/logs/DeepCAVE/mnist_pytorch/run_3/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 16,
       "upper": 256,
-      "default": 136
+      "default": 136,
+      "q": null
     },
     {
       "name": "dropout_rate",
@@ -25,7 +26,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 0.9,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -33,7 +35,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 0.1,
-      "default": 0.0031622777
+      "default": 0.0031622777,
+      "q": null
     },
     {
       "name": "model",
@@ -51,7 +54,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     },
     {
       "name": "num_neurons_layer2",
@@ -59,7 +63,8 @@
       "log": false,
       "lower": 5,
       "upper": 100,
-      "default": 52
+      "default": 52,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/mlp/run_1/configspace.json
+++ b/logs/SMAC3v1/mlp/run_1/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 1
+      "default": 1,
+      "q": null
     },
     {
       "name": "n_neurons",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 8,
       "upper": 1024,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "solver",
@@ -44,7 +46,8 @@
       "log": false,
       "lower": 30,
       "upper": 300,
-      "default": 200
+      "default": 200,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -63,7 +66,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 1.0,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-0/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-0/configspace.json
@@ -38,7 +38,8 @@
       "log": false,
       "lower": 1,
       "upper": 8,
-      "default": 4
+      "default": 4,
+      "q": null
     },
     {
       "name": "backbone:num_layers",
@@ -46,7 +47,8 @@
       "log": false,
       "lower": 0,
       "upper": 3,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "backbone:skip_connection",
@@ -64,7 +66,8 @@
       "log": false,
       "lower": 32,
       "upper": 512,
-      "default": 128
+      "default": 128,
+      "q": null
     },
     {
       "name": "model:__choice__",
@@ -107,7 +110,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.8,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_1",
@@ -115,7 +119,8 @@
       "log": false,
       "lower": 8,
       "upper": 16,
-      "default": 12
+      "default": 12,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_2",
@@ -123,7 +128,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_3",
@@ -131,7 +137,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "model:dagmm:activation",
@@ -151,7 +158,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_1",
@@ -159,7 +167,8 @@
       "log": false,
       "lower": 0.01,
       "upper": 0.5,
-      "default": 0.1
+      "default": 0.1,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_2",
@@ -167,7 +176,8 @@
       "log": false,
       "lower": 0.0001,
       "upper": 0.05,
-      "default": 0.005
+      "default": 0.005,
+      "q": null
     },
     {
       "name": "model:dagmm:num_units",
@@ -175,7 +185,8 @@
       "log": false,
       "lower": 2,
       "upper": 20,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:K",
@@ -183,7 +194,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 1.0,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:T",
@@ -191,7 +203,8 @@
       "log": false,
       "lower": 3,
       "upper": 100,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:__choice__",
@@ -210,7 +223,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:beta2",
@@ -218,7 +232,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:lr",
@@ -226,7 +241,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:weight_decay",
@@ -234,7 +250,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:lr",
@@ -242,7 +259,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:momentum",
@@ -250,7 +268,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:weight_decay",
@@ -258,7 +277,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr",
@@ -266,7 +286,8 @@
       "log": false,
       "lower": 1e-05,
       "upper": 2.0,
-      "default": 1.0
+      "default": 1.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr_decay",
@@ -274,7 +295,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:weight_decay",
@@ -282,7 +304,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta1",
@@ -290,7 +313,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta2",
@@ -298,7 +322,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:lr",
@@ -306,7 +331,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:weight_decay",
@@ -314,7 +340,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:lr",
@@ -322,7 +349,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:momentum",
@@ -330,7 +358,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:weight_decay",
@@ -338,7 +367,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-25/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-25/configspace.json
@@ -38,7 +38,8 @@
       "log": false,
       "lower": 1,
       "upper": 8,
-      "default": 4
+      "default": 4,
+      "q": null
     },
     {
       "name": "backbone:num_layers",
@@ -46,7 +47,8 @@
       "log": false,
       "lower": 0,
       "upper": 3,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "backbone:skip_connection",
@@ -64,7 +66,8 @@
       "log": false,
       "lower": 32,
       "upper": 512,
-      "default": 128
+      "default": 128,
+      "q": null
     },
     {
       "name": "model:__choice__",
@@ -107,7 +110,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.8,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_1",
@@ -115,7 +119,8 @@
       "log": false,
       "lower": 8,
       "upper": 16,
-      "default": 12
+      "default": 12,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_2",
@@ -123,7 +128,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_3",
@@ -131,7 +137,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "model:dagmm:activation",
@@ -151,7 +158,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_1",
@@ -159,7 +167,8 @@
       "log": false,
       "lower": 0.01,
       "upper": 0.5,
-      "default": 0.1
+      "default": 0.1,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_2",
@@ -167,7 +176,8 @@
       "log": false,
       "lower": 0.0001,
       "upper": 0.05,
-      "default": 0.005
+      "default": 0.005,
+      "q": null
     },
     {
       "name": "model:dagmm:num_units",
@@ -175,7 +185,8 @@
       "log": false,
       "lower": 2,
       "upper": 20,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:K",
@@ -183,7 +194,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 1.0,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:T",
@@ -191,7 +203,8 @@
       "log": false,
       "lower": 3,
       "upper": 100,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:__choice__",
@@ -210,7 +223,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:beta2",
@@ -218,7 +232,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:lr",
@@ -226,7 +241,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:weight_decay",
@@ -234,7 +250,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:lr",
@@ -242,7 +259,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:momentum",
@@ -250,7 +268,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:weight_decay",
@@ -258,7 +277,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr",
@@ -266,7 +286,8 @@
       "log": false,
       "lower": 1e-05,
       "upper": 2.0,
-      "default": 1.0
+      "default": 1.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr_decay",
@@ -274,7 +295,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:weight_decay",
@@ -282,7 +304,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta1",
@@ -290,7 +313,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta2",
@@ -298,7 +322,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:lr",
@@ -306,7 +331,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:weight_decay",
@@ -314,7 +340,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:lr",
@@ -322,7 +349,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:momentum",
@@ -330,7 +358,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:weight_decay",
@@ -338,7 +367,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-50/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-50/configspace.json
@@ -38,7 +38,8 @@
       "log": false,
       "lower": 1,
       "upper": 8,
-      "default": 4
+      "default": 4,
+      "q": null
     },
     {
       "name": "backbone:num_layers",
@@ -46,7 +47,8 @@
       "log": false,
       "lower": 0,
       "upper": 3,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "backbone:skip_connection",
@@ -107,7 +109,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.8,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_1",
@@ -115,7 +118,8 @@
       "log": false,
       "lower": 8,
       "upper": 16,
-      "default": 12
+      "default": 12,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_2",
@@ -123,7 +127,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_3",
@@ -131,7 +136,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "model:dagmm:activation",
@@ -151,7 +157,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_1",
@@ -159,7 +166,8 @@
       "log": false,
       "lower": 0.01,
       "upper": 0.5,
-      "default": 0.1
+      "default": 0.1,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_2",
@@ -167,7 +175,8 @@
       "log": false,
       "lower": 0.0001,
       "upper": 0.05,
-      "default": 0.005
+      "default": 0.005,
+      "q": null
     },
     {
       "name": "model:dagmm:num_units",
@@ -175,7 +184,8 @@
       "log": false,
       "lower": 2,
       "upper": 20,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:K",
@@ -183,7 +193,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 1.0,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:T",
@@ -191,7 +202,8 @@
       "log": false,
       "lower": 3,
       "upper": 100,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:__choice__",
@@ -210,7 +222,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:beta2",
@@ -218,7 +231,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:lr",
@@ -226,7 +240,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:weight_decay",
@@ -234,7 +249,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:lr",
@@ -242,7 +258,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:momentum",
@@ -250,7 +267,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:weight_decay",
@@ -258,7 +276,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr",
@@ -266,7 +285,8 @@
       "log": false,
       "lower": 1e-05,
       "upper": 2.0,
-      "default": 1.0
+      "default": 1.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr_decay",
@@ -274,7 +294,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:weight_decay",
@@ -282,7 +303,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta1",
@@ -290,7 +312,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta2",
@@ -298,7 +321,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:lr",
@@ -306,7 +330,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:weight_decay",
@@ -314,7 +339,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:lr",
@@ -322,7 +348,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:momentum",
@@ -330,7 +357,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:weight_decay",
@@ -338,7 +366,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-50/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/DEHB-pendigits-015-0-50/configspace.json
@@ -66,7 +66,8 @@
       "log": false,
       "lower": 32,
       "upper": 512,
-      "default": 128
+      "default": 128,
+      "q": null
     },
     {
       "name": "model:__choice__",

--- a/logs/SMAC3v1/outlier-detection/SMAC-pendigits-015-0-0/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/SMAC-pendigits-015-0-0/configspace.json
@@ -38,7 +38,8 @@
       "log": false,
       "lower": 1,
       "upper": 8,
-      "default": 4
+      "default": 4,
+      "q": null
     },
     {
       "name": "backbone:num_layers",
@@ -46,7 +47,8 @@
       "log": false,
       "lower": 0,
       "upper": 3,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "backbone:skip_connection",
@@ -64,7 +66,8 @@
       "log": false,
       "lower": 32,
       "upper": 512,
-      "default": 128
+      "default": 128,
+      "q": null
     },
     {
       "name": "model:__choice__",
@@ -107,7 +110,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.8,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_1",
@@ -115,7 +119,8 @@
       "log": false,
       "lower": 8,
       "upper": 16,
-      "default": 12
+      "default": 12,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_2",
@@ -123,7 +128,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_3",
@@ -131,7 +137,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "model:dagmm:activation",
@@ -151,7 +158,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_1",
@@ -159,7 +167,8 @@
       "log": false,
       "lower": 0.01,
       "upper": 0.5,
-      "default": 0.1
+      "default": 0.1,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_2",
@@ -167,7 +176,8 @@
       "log": false,
       "lower": 0.0001,
       "upper": 0.05,
-      "default": 0.005
+      "default": 0.005,
+      "q": null
     },
     {
       "name": "model:dagmm:num_units",
@@ -175,7 +185,8 @@
       "log": false,
       "lower": 2,
       "upper": 20,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:K",
@@ -183,7 +194,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 1.0,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:T",
@@ -191,7 +203,8 @@
       "log": false,
       "lower": 3,
       "upper": 100,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:__choice__",
@@ -210,7 +223,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:beta2",
@@ -218,7 +232,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:lr",
@@ -226,7 +241,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:weight_decay",
@@ -234,7 +250,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:lr",
@@ -242,7 +259,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:momentum",
@@ -250,7 +268,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:weight_decay",
@@ -258,7 +277,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr",
@@ -266,7 +286,8 @@
       "log": false,
       "lower": 1e-05,
       "upper": 2.0,
-      "default": 1.0
+      "default": 1.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr_decay",
@@ -274,7 +295,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:weight_decay",
@@ -282,7 +304,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta1",
@@ -290,7 +313,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta2",
@@ -298,7 +322,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:lr",
@@ -306,7 +331,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:weight_decay",
@@ -314,7 +340,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:lr",
@@ -322,7 +349,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:momentum",
@@ -330,7 +358,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:weight_decay",
@@ -338,7 +367,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/outlier-detection/SMAC-pendigits-015-0-25/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/SMAC-pendigits-015-0-25/configspace.json
@@ -38,7 +38,8 @@
       "log": false,
       "lower": 1,
       "upper": 8,
-      "default": 4
+      "default": 4,
+      "q": null
     },
     {
       "name": "backbone:num_layers",
@@ -46,7 +47,8 @@
       "log": false,
       "lower": 0,
       "upper": 3,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "backbone:skip_connection",
@@ -64,7 +66,8 @@
       "log": false,
       "lower": 32,
       "upper": 512,
-      "default": 128
+      "default": 128,
+      "q": null
     },
     {
       "name": "model:__choice__",
@@ -107,7 +110,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.8,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_1",
@@ -115,7 +119,8 @@
       "log": false,
       "lower": 8,
       "upper": 16,
-      "default": 12
+      "default": 12,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_2",
@@ -123,7 +128,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_3",
@@ -131,7 +137,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "model:dagmm:activation",
@@ -151,7 +158,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_1",
@@ -159,7 +167,8 @@
       "log": false,
       "lower": 0.01,
       "upper": 0.5,
-      "default": 0.1
+      "default": 0.1,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_2",
@@ -167,7 +176,8 @@
       "log": false,
       "lower": 0.0001,
       "upper": 0.05,
-      "default": 0.005
+      "default": 0.005,
+      "q": null
     },
     {
       "name": "model:dagmm:num_units",
@@ -175,7 +185,8 @@
       "log": false,
       "lower": 2,
       "upper": 20,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:K",
@@ -183,7 +194,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 1.0,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:T",
@@ -191,7 +203,8 @@
       "log": false,
       "lower": 3,
       "upper": 100,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:__choice__",
@@ -210,7 +223,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:beta2",
@@ -218,7 +232,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:lr",
@@ -226,7 +241,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:weight_decay",
@@ -234,7 +250,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:lr",
@@ -242,7 +259,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:momentum",
@@ -250,7 +268,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:weight_decay",
@@ -258,7 +277,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr",
@@ -266,7 +286,8 @@
       "log": false,
       "lower": 1e-05,
       "upper": 2.0,
-      "default": 1.0
+      "default": 1.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr_decay",
@@ -274,7 +295,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:weight_decay",
@@ -282,7 +304,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta1",
@@ -290,7 +313,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta2",
@@ -298,7 +322,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:lr",
@@ -306,7 +331,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:weight_decay",
@@ -314,7 +340,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:lr",
@@ -322,7 +349,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:momentum",
@@ -330,7 +358,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:weight_decay",
@@ -338,7 +367,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v1/outlier-detection/SMAC-pendigits-015-0-50/configspace.json
+++ b/logs/SMAC3v1/outlier-detection/SMAC-pendigits-015-0-50/configspace.json
@@ -38,7 +38,8 @@
       "log": false,
       "lower": 1,
       "upper": 8,
-      "default": 4
+      "default": 4,
+      "q": null
     },
     {
       "name": "backbone:num_layers",
@@ -46,7 +47,8 @@
       "log": false,
       "lower": 0,
       "upper": 3,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "backbone:skip_connection",
@@ -64,7 +66,8 @@
       "log": false,
       "lower": 32,
       "upper": 512,
-      "default": 128
+      "default": 128,
+      "q": null
     },
     {
       "name": "model:__choice__",
@@ -107,7 +110,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.8,
-      "default": 0.5
+      "default": 0.5,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_1",
@@ -115,7 +119,8 @@
       "log": false,
       "lower": 8,
       "upper": 16,
-      "default": 12
+      "default": 12,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_2",
@@ -123,7 +128,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "backbone:num_units_layer_3",
@@ -131,7 +137,8 @@
       "log": false,
       "lower": 4,
       "upper": 12,
-      "default": 8
+      "default": 8,
+      "q": null
     },
     {
       "name": "model:dagmm:activation",
@@ -151,7 +158,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 2
+      "default": 2,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_1",
@@ -159,7 +167,8 @@
       "log": false,
       "lower": 0.01,
       "upper": 0.5,
-      "default": 0.1
+      "default": 0.1,
+      "q": null
     },
     {
       "name": "model:dagmm:lambda_2",
@@ -167,7 +176,8 @@
       "log": false,
       "lower": 0.0001,
       "upper": 0.05,
-      "default": 0.005
+      "default": 0.005,
+      "q": null
     },
     {
       "name": "model:dagmm:num_units",
@@ -175,7 +185,8 @@
       "log": false,
       "lower": 2,
       "upper": 20,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:K",
@@ -183,7 +194,8 @@
       "log": false,
       "lower": 0.1,
       "upper": 1.0,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:T",
@@ -191,7 +203,8 @@
       "log": false,
       "lower": 3,
       "upper": 100,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:__choice__",
@@ -210,7 +223,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:beta2",
@@ -218,7 +232,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:lr",
@@ -226,7 +241,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:AdamWOptimizer:weight_decay",
@@ -234,7 +250,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:lr",
@@ -242,7 +259,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:momentum",
@@ -250,7 +268,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "optimizer:SGDOptimizer:weight_decay",
@@ -258,7 +277,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr",
@@ -266,7 +286,8 @@
       "log": false,
       "lower": 1e-05,
       "upper": 2.0,
-      "default": 1.0
+      "default": 1.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:lr_decay",
@@ -274,7 +295,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdagradOptimizer:weight_decay",
@@ -282,7 +304,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta1",
@@ -290,7 +313,8 @@
       "log": false,
       "lower": 0.85,
       "upper": 0.999,
-      "default": 0.9
+      "default": 0.9,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:beta2",
@@ -298,7 +322,8 @@
       "log": false,
       "lower": 0.9,
       "upper": 0.9999,
-      "default": 0.999
+      "default": 0.999,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:lr",
@@ -306,7 +331,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:AdamWOptimizer:weight_decay",
@@ -314,7 +340,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.01
+      "default": 0.01,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:lr",
@@ -322,7 +349,8 @@
       "log": true,
       "lower": 1e-05,
       "upper": 0.1,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:momentum",
@@ -330,7 +358,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.99,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     },
     {
       "name": "model:dasvdd:center_optimizer:SGDOptimizer:weight_decay",
@@ -338,7 +367,8 @@
       "log": false,
       "lower": 0.0,
       "upper": 0.1,
-      "default": 0.0
+      "default": 0.0,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v2/mlp/run_1/configspace.json
+++ b/logs/SMAC3v2/mlp/run_1/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 1
+      "default": 1,
+      "q": null
     },
     {
       "name": "n_neurons",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 8,
       "upper": 256,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "solver",
@@ -44,7 +46,8 @@
       "log": false,
       "lower": 30,
       "upper": 300,
-      "default": 200
+      "default": 200,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -63,7 +66,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 1.0,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v2/mlp/run_2/configspace.json
+++ b/logs/SMAC3v2/mlp/run_2/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 1
+      "default": 1,
+      "q": null
     },
     {
       "name": "n_neurons",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 8,
       "upper": 256,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "solver",
@@ -44,7 +46,8 @@
       "log": false,
       "lower": 30,
       "upper": 300,
-      "default": 200
+      "default": 200,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -63,7 +66,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 1.0,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     }
   ],
   "conditions": [

--- a/logs/SMAC3v2/mlp/run_3/configspace.json
+++ b/logs/SMAC3v2/mlp/run_3/configspace.json
@@ -17,7 +17,8 @@
       "log": false,
       "lower": 1,
       "upper": 5,
-      "default": 1
+      "default": 1,
+      "q": null
     },
     {
       "name": "n_neurons",
@@ -25,7 +26,8 @@
       "log": true,
       "lower": 8,
       "upper": 256,
-      "default": 10
+      "default": 10,
+      "q": null
     },
     {
       "name": "solver",
@@ -44,7 +46,8 @@
       "log": false,
       "lower": 30,
       "upper": 300,
-      "default": 200
+      "default": 200,
+      "q": null
     },
     {
       "name": "learning_rate",
@@ -63,7 +66,8 @@
       "log": true,
       "lower": 0.0001,
       "upper": 1.0,
-      "default": 0.001
+      "default": 0.001,
+      "q": null
     }
   ],
   "conditions": [


### PR DESCRIPTION
These were left out of serialization of configspaces before, meaning DeepCave with a newer version of ConfigSpace could not load them. I put them in as `"q": null`.