### PR TITLE
Add seaborn as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ jsonlines>=3.0.0
 pandas>=1.3.4
 numpy>=1.22.2
 matplotlib>=3.5.1
+seaborn>=0.12.2
 pyyaml
 
 # AutoML packages


### PR DESCRIPTION
Closes https://github.com/automl/DeepCAVE/issues/73

Adds the most recent seaborn release (v0.12.2; 2022-12-30) as depependency.


Seaborn is used here: https://github.com/automl/DeepCAVE/blob/1851126c064a3120299250fb39b2c00d00abbc2e/deepcave/utils/styled_plot.py#L150 

and here: https://github.com/automl/DeepCAVE/blob/1851126c064a3120299250fb39b2c00d00abbc2e/deepcave/utils/styled_plot.py#L28

but was not part of the requirements.txt

