### PR TITLE
Fix non-existent 'RUNNING' status for runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.1.4
+
+## Bug-Fixes
+- Don't convert BOHB runs with status 'running' (consistent with SMAC).
+
 # Version 1.1.3
 
 ## Bug-Fixes

--- a/deepcave/runs/converters/bohb.py
+++ b/deepcave/runs/converters/bohb.py
@@ -49,7 +49,6 @@ class BOHBRun(Run):
 
         first_starttime = None
         for bohb_run in bohb.get_all_runs():
-
             times = bohb_run.time_stamps
             starttime = times["started"]
             endtime = times["finished"]
@@ -77,7 +76,7 @@ class BOHBRun(Run):
             if "SUCCESS" in status or "TERMINATED" in status or "COMPLETED" in status:
                 status = Status.SUCCESS
             elif "RUNNING" in status or "QUEUED" in status or "REVIEW" in status:
-                status = Status.RUNNING
+                continue
             else:
                 status = Status.CRASHED
 


### PR DESCRIPTION
Ignore running BOHB runs instead of assigning non-existent `RUNNING` status (similar to how it was already done for SMAC runs).

Closes #79 