### PR TITLE
Fix use of config

### DIFF
--- a/deepcave/__init__.py
+++ b/deepcave/__init__.py
@@ -138,13 +138,17 @@ else:
         from deepcave.runs.objective import Objective  # noqa
         from deepcave.runs.recorder import Recorder  # noqa
         from deepcave.utils.configs import parse_config
+        from deepcave.utils.notification import Notification
 
         config_name = None
         if "--config" in sys.argv:
             config_name = sys.argv[sys.argv.index("--config") + 1]
         config = parse_config(config_name)
 
-        __all__ = ["version", "Recorder", "Objective", "config"]
+        # Notifications
+        notification = Notification()
+
+        __all__ = ["version", "Recorder", "Objective", "notification", "config"]
     except ModuleNotFoundError:
         __all__ = ["version"]
 

--- a/deepcave/__init__.py
+++ b/deepcave/__init__.py
@@ -137,14 +137,19 @@ else:
     try:
         from deepcave.runs.objective import Objective  # noqa
         from deepcave.runs.recorder import Recorder  # noqa
+        from deepcave.utils.configs import parse_config
 
-        __all__ = ["version", "Recorder", "Objective"]
+        config_name = None
+        if "--config" in sys.argv:
+            config_name = sys.argv[sys.argv.index("--config") + 1]
+        config = parse_config(config_name)
+
+        __all__ = ["version", "Recorder", "Objective", "config"]
     except ModuleNotFoundError:
         __all__ = ["version"]
 
 
 _api_mode = False if "app" in globals() else True
-
 
 # This TypeVar is necessary to ensure that the decorator works with arbitrary signatures.
 F = TypeVar("F", bound=Callable[..., Any])

--- a/deepcave/plugins/__init__.py
+++ b/deepcave/plugins/__init__.py
@@ -115,9 +115,9 @@ class Plugin(Layout, ABC):
         str
             Url for the plugin as string.
         """
-        from deepcave.config import Config
+        from deepcave import config
 
-        return f"http://{Config.DASH_ADDRESS}:{Config.DASH_PORT}/plugins/{cls.id}"
+        return f"http://{config.DASH_ADDRESS}:{config.DASH_PORT}/plugins/{cls.id}"
 
     @staticmethod
     def check_run_compatibility(run: AbstractRun) -> bool:

--- a/deepcave/plugins/budget/budget_correlation.py
+++ b/deepcave/plugins/budget/budget_correlation.py
@@ -19,8 +19,7 @@ import plotly.graph_objs as go
 from dash import dcc, html
 from scipy import stats
 
-from deepcave import notification
-from deepcave.config import Config
+from deepcave import config, notification
 from deepcave.plugins.dynamic import DynamicPlugin
 from deepcave.runs import AbstractRun, Status
 from deepcave.utils.layout import create_table, get_select_options
@@ -220,7 +219,7 @@ class BudgetCorrelation(DynamicPlugin):
                 [
                     dbc.Tab(
                         dcc.Graph(
-                            id=register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT}
+                            id=register("graph", "figure"), style={"height": config.FIGURE_HEIGHT}
                         ),
                         label="Graph",
                     ),
@@ -298,7 +297,7 @@ class BudgetCorrelation(DynamicPlugin):
         layout = go.Layout(
             xaxis=dict(title="Budget"),
             yaxis=dict(title="Correlation"),
-            margin=Config.FIGURE_MARGIN,
+            margin=config.FIGURE_MARGIN,
             legend=dict(title="Budgets"),
         )
 

--- a/deepcave/plugins/hyperparameter/importances.py
+++ b/deepcave/plugins/hyperparameter/importances.py
@@ -20,7 +20,7 @@ from ConfigSpace import ConfigurationSpace, Constant
 from dash import dcc, html
 from dash.exceptions import PreventUpdate
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.evaluators.fanova import fANOVA as GlobalEvaluator
 from deepcave.evaluators.lpi import LPI as LocalEvaluator
 from deepcave.plugins.static import StaticPlugin
@@ -357,7 +357,7 @@ class Importances(StaticPlugin):
         dcc.Graph
             Layout for the output block.
         """
-        return dcc.Graph(register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT})
+        return dcc.Graph(register("graph", "figure"), style={"height": config.FIGURE_HEIGHT})
 
     @staticmethod
     def load_outputs(run, inputs, outputs) -> go.Figure:  # type: ignore
@@ -452,7 +452,7 @@ class Importances(StaticPlugin):
             barmode="group",
             yaxis_title="Importance",
             legend={"title": "Budget"},
-            margin=Config.FIGURE_MARGIN,
+            margin=config.FIGURE_MARGIN,
             xaxis=dict(tickangle=-45),
         )
         save_image(figure, "importances.pdf")

--- a/deepcave/plugins/hyperparameter/pdp.py
+++ b/deepcave/plugins/hyperparameter/pdp.py
@@ -25,7 +25,7 @@ import plotly.graph_objs as go
 from dash import dcc, html
 from pyPDP.algorithms.pdp import PDP
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.evaluators.epm.random_forest_surrogate import RandomForestSurrogate
 from deepcave.plugins.static import StaticPlugin
 from deepcave.runs import Status
@@ -366,7 +366,7 @@ class PartialDependencies(StaticPlugin):
         dcc.Graph
             Layout for the output block.
         """
-        return dcc.Graph(register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT})
+        return dcc.Graph(register("graph", "figure"), style={"height": config.FIGURE_HEIGHT})
 
     @staticmethod
     def get_pdp_figure(  # type: ignore
@@ -503,7 +503,7 @@ class PartialDependencies(StaticPlugin):
                 dict(
                     xaxis=dict(tickvals=x_tickvals, ticktext=x_ticktext, title=hp1_name),
                     yaxis=dict(tickvals=y_tickvals, ticktext=y_ticktext, title=hp2_name),
-                    margin=Config.FIGURE_MARGIN,
+                    margin=config.FIGURE_MARGIN,
                     title=title,
                 )
             )

--- a/deepcave/plugins/hyperparameter/symbolic_explanations.py
+++ b/deepcave/plugins/hyperparameter/symbolic_explanations.py
@@ -27,7 +27,7 @@ from dash import dcc, html
 from gplearn.genetic import SymbolicRegressor
 from pyPDP.algorithms.pdp import PDP
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.evaluators.epm.random_forest_surrogate import RandomForestSurrogate
 from deepcave.plugins.hyperparameter.pdp import PartialDependencies
 from deepcave.plugins.static import StaticPlugin
@@ -491,8 +491,8 @@ class SymbolicExplanations(StaticPlugin):
             Layout for the output block.
         """
         return [
-            dcc.Graph(register("symb_graph", "figure"), style={"height": Config.FIGURE_HEIGHT}),
-            dcc.Graph(register("pdp_graph", "figure"), style={"height": Config.FIGURE_HEIGHT}),
+            dcc.Graph(register("symb_graph", "figure"), style={"height": config.FIGURE_HEIGHT}),
+            dcc.Graph(register("pdp_graph", "figure"), style={"height": config.FIGURE_HEIGHT}),
         ]
 
     @staticmethod
@@ -592,7 +592,7 @@ class SymbolicExplanations(StaticPlugin):
                 dict(
                     xaxis=dict(tickvals=x_tickvals, ticktext=x_ticktext, title=hp1_name),
                     yaxis=dict(tickvals=y_tickvals, ticktext=y_ticktext, title=hp2_name),
-                    margin=Config.FIGURE_MARGIN,
+                    margin=config.FIGURE_MARGIN,
                     title=expr,
                 )
             )

--- a/deepcave/plugins/objective/configuration_cube.py
+++ b/deepcave/plugins/objective/configuration_cube.py
@@ -19,7 +19,7 @@ import plotly.graph_objs as go
 from dash import dcc, html
 from dash.exceptions import PreventUpdate
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.plugins.dynamic import DynamicPlugin
 from deepcave.runs import AbstractRun, Status
 from deepcave.utils.compression import deserialize, serialize
@@ -294,7 +294,7 @@ class ConfigurationCube(DynamicPlugin):
         Tuple[dcc.Graph,]
             Layout for the output block.
         """
-        return (dcc.Graph(register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT}),)
+        return (dcc.Graph(register("graph", "figure"), style={"height": config.FIGURE_HEIGHT}),)
 
     @staticmethod
     def load_outputs(run, inputs, outputs) -> go.Figure:  # type: ignore
@@ -417,7 +417,7 @@ class ConfigurationCube(DynamicPlugin):
             layout = go.Layout(**layout_kwargs)
 
         figure = go.Figure(data=trace, layout=layout)
-        figure.update_layout(dict(margin=Config.FIGURE_MARGIN))
+        figure.update_layout(dict(margin=config.FIGURE_MARGIN))
         save_image(figure, "configuration_cube.pdf")
 
         return figure

--- a/deepcave/plugins/objective/cost_over_time.py
+++ b/deepcave/plugins/objective/cost_over_time.py
@@ -19,7 +19,7 @@ import plotly.graph_objs as go
 from dash import dcc, html
 from dash.exceptions import PreventUpdate
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.plugins.dynamic import DynamicPlugin
 from deepcave.runs import AbstractRun, check_equality
 from deepcave.utils.layout import get_select_options, help_button
@@ -275,7 +275,7 @@ class CostOverTime(DynamicPlugin):
         dcc.Graph
             The layouts for the output block.
         """
-        return dcc.Graph(register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT})
+        return dcc.Graph(register("graph", "figure"), style={"height": config.FIGURE_HEIGHT})
 
     @staticmethod
     def load_outputs(runs, inputs, outputs) -> go.Figure:  # type: ignore
@@ -393,7 +393,7 @@ class CostOverTime(DynamicPlugin):
         layout = go.Layout(
             xaxis=dict(title=xaxis_label, type=type),
             yaxis=dict(title=objective.name),
-            margin=Config.FIGURE_MARGIN,
+            margin=config.FIGURE_MARGIN,
         )
 
         figure = go.Figure(data=traces, layout=layout)

--- a/deepcave/plugins/objective/parallel_coordinates.py
+++ b/deepcave/plugins/objective/parallel_coordinates.py
@@ -20,7 +20,7 @@ import plotly.graph_objs as go
 from dash import dcc, html
 from dash.exceptions import PreventUpdate
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.constants import VALUE_RANGE
 from deepcave.evaluators.fanova import fANOVA
 from deepcave.plugins.static import StaticPlugin
@@ -320,7 +320,7 @@ class ParallelCoordinates(StaticPlugin):
         dcc.Graph
             The layouts for the output block.
         """
-        return dcc.Graph(register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT})
+        return dcc.Graph(register("graph", "figure"), style={"height": config.FIGURE_HEIGHT})
 
     @staticmethod
     def load_outputs(run, inputs, outputs) -> go.Figure:  # type: ignore

--- a/deepcave/plugins/objective/pareto_front.py
+++ b/deepcave/plugins/objective/pareto_front.py
@@ -17,7 +17,7 @@ import numpy as np
 import plotly.graph_objs as go
 from dash import dcc, html
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.plugins.dynamic import DynamicPlugin
 from deepcave.runs import AbstractRun, Status, check_equality
 from deepcave.utils.layout import get_select_options, help_button
@@ -329,7 +329,7 @@ class ParetoFront(DynamicPlugin):
         dcc.Graph
             The layout for the output block.
         """
-        return dcc.Graph(register("graph", "figure"), style={"height": Config.FIGURE_HEIGHT})
+        return dcc.Graph(register("graph", "figure"), style={"height": config.FIGURE_HEIGHT})
 
     @staticmethod
     def load_outputs(runs, inputs, outputs) -> go.Figure:  # type: ignore
@@ -437,7 +437,7 @@ class ParetoFront(DynamicPlugin):
             layout = go.Layout(
                 xaxis=dict(title=objective_1.name),
                 yaxis=dict(title=objective_2.name),
-                margin=Config.FIGURE_MARGIN,
+                margin=config.FIGURE_MARGIN,
             )
         else:
             layout = None

--- a/deepcave/plugins/static.py
+++ b/deepcave/plugins/static.py
@@ -389,12 +389,12 @@ class StaticPlugin(Plugin, ABC):
         List[Component]
             Layout as list of components.
         """
-        from deepcave.config import Config
+        from deepcave import config
 
         self._setup()
 
         components = [
-            dcc.Interval(id=self.get_internal_id("update-interval"), interval=Config.REFRESH_RATE),
+            dcc.Interval(id=self.get_internal_id("update-interval"), interval=config.REFRESH_RATE),
             dcc.Store(id=self.get_internal_id("update-interval-output"), data=0),
         ]
         components += super().__call__(True)

--- a/deepcave/plugins/summary/configurations.py
+++ b/deepcave/plugins/summary/configurations.py
@@ -19,7 +19,7 @@ import pandas as pd
 import plotly.graph_objs as go
 from dash import dcc, html
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.constants import VALUE_RANGE
 from deepcave.plugins.dynamic import DynamicPlugin
 from deepcave.runs import AbstractRun, Status
@@ -286,7 +286,7 @@ class Configurations(DynamicPlugin):
                     dbc.Tab(
                         dcc.Graph(
                             id=register("performance_graph", "figure"),
-                            style={"height": Config.FIGURE_HEIGHT},
+                            style={"height": config.FIGURE_HEIGHT},
                         ),
                         label="Graph",
                     ),
@@ -300,7 +300,7 @@ class Configurations(DynamicPlugin):
                     dbc.Tab(
                         dcc.Graph(
                             id=register("configspace_graph", "figure"),
-                            style={"height": Config.FIGURE_HEIGHT},
+                            style={"height": config.FIGURE_HEIGHT},
                         ),
                         label="Graph",
                     ),
@@ -356,7 +356,7 @@ class Configurations(DynamicPlugin):
             objective_data.append(trace)
 
         layout_kwargs: Dict[str, Any] = {
-            "margin": Config.FIGURE_MARGIN,
+            "margin": config.FIGURE_MARGIN,
             "xaxis": {"title": "Budget", "domain": [0.05 * len(run.get_objectives()), 1]},
         }
 

--- a/deepcave/plugins/summary/footprint.py
+++ b/deepcave/plugins/summary/footprint.py
@@ -16,7 +16,7 @@ import dash_bootstrap_components as dbc
 import plotly.graph_objs as go
 from dash import dcc, html
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.evaluators.footprint import Footprint as Evaluator
 from deepcave.plugins.static import StaticPlugin
 from deepcave.utils.layout import get_select_options, help_button
@@ -296,13 +296,13 @@ class FootPrint(StaticPlugin):
             [
                 dbc.Tab(
                     dcc.Graph(
-                        id=register("performance", "figure"), style={"height": Config.FIGURE_HEIGHT}
+                        id=register("performance", "figure"), style={"height": config.FIGURE_HEIGHT}
                     ),
                     label="Performance",
                 ),
                 dbc.Tab(
                     dcc.Graph(
-                        id=register("area", "figure"), style={"height": Config.FIGURE_HEIGHT}
+                        id=register("area", "figure"), style={"height": config.FIGURE_HEIGHT}
                     ),
                     label="Coverage",
                 ),
@@ -410,7 +410,7 @@ class FootPrint(StaticPlugin):
         layout = go.Layout(
             xaxis=dict(title=None, tickvals=[]),
             yaxis=dict(title=None, tickvals=[]),
-            margin=Config.FIGURE_MARGIN,
+            margin=config.FIGURE_MARGIN,
         )
 
         performance = go.Figure(data=[performance_data] + traces, layout=layout)

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -28,7 +28,7 @@ from ConfigSpace.hyperparameters import (
 )
 from dash import dcc, html
 
-from deepcave.config import Config
+from deepcave import config
 from deepcave.plugins.dynamic import DynamicPlugin
 from deepcave.plugins.summary.configurations import Configurations
 from deepcave.runs.group import Group
@@ -83,14 +83,14 @@ class Overview(DynamicPlugin):
                     dbc.Tab(
                         dcc.Graph(
                             id=register("status_statistics", "figure"),
-                            style={"height": Config.FIGURE_HEIGHT},
+                            style={"height": config.FIGURE_HEIGHT},
                         ),
                         label="Barplot",
                     ),
                     dbc.Tab(
                         dcc.Graph(
                             id=register("config_statistics", "figure"),
-                            style={"height": Config.FIGURE_HEIGHT},
+                            style={"height": config.FIGURE_HEIGHT},
                         ),
                         label="Heatmap",
                     ),
@@ -383,7 +383,7 @@ class Overview(DynamicPlugin):
             barmode="group",
             xaxis=dict(title="Status"),
             yaxis=dict(title="Number of configurations"),
-            margin=Config.FIGURE_MARGIN,
+            margin=config.FIGURE_MARGIN,
         )
         stats_figure = go.Figure(data=stats_data, layout=stats_layout)
         save_image(stats_figure, "status_bar.pdf")
@@ -392,7 +392,7 @@ class Overview(DynamicPlugin):
             legend={"title": "Status"},
             xaxis=dict(title="Budget"),
             yaxis=dict(title="Configuration ID"),
-            margin=Config.FIGURE_MARGIN,
+            margin=config.FIGURE_MARGIN,
         )
         config_figure = go.Figure(
             data=get_discrete_heatmap(


### PR DESCRIPTION
Basically, undo most of the (unnecessary) changes made in https://github.com/automl/DeepCAVE/pull/103, which were done to allow accessing the attributes of config when using the API mode, e.g. executing `examples/api/importances.py`.

The reason using the API mode did not work was that config was only added to the deepcave-attributes when executing server.py, which is not the case when running the API examples. Thus, `from deepcave import config` failed in these cases.

So now, instead of importing the Config class via `from deepcave.config import Config`, config is always added to the deepcave-attributes, such that it is available when running the API examples as well.