### PR TITLE
added parent directory to run display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.2.1
+
+## Quality of Life
+- Runs now get displayed witn their parent directory for better distinguishability
+
 # Version 1.2
 
 ## Plugins

--- a/deepcave/plugins/__init__.py
+++ b/deepcave/plugins/__init__.py
@@ -1145,8 +1145,12 @@ class Plugin(Layout, ABC):
         for run in runs:
             if check_run_compatibility(run):
                 try:
+                    run_path = run.path
+                    if run_path is not None:
+                        run_name = run_path.parent.name + "/" + run.name
+
                     values.append(run.id)
-                    labels.append(run.name)
+                    labels.append(run_name)
                     disabled.append(False)
                 except Exception:
                     pass


### PR DESCRIPTION
For plugins that use the run selection, instead of "run_1" now there is also the runs parent directory like "minimal/run_1".