### PR TITLE
Fix/importances when single budget entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Increase plot font sizes.
 
 ## Bug-Fixes
-- Quantify LPI importance via variance instead of importance over mean (#152)
+- Use normalized LPI importance via variance instead of importance over mean (#152)
 - Return nan as importance values if variance is 0. for a hyperparameter / budget (#152)
 
 # Version 1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Runs now get displayed with their parent directory for better distinguishability
 - Increase plot font sizes.
 
+## Bug-Fixes
+- Quantify LPI importance via variance instead of importance over mean (not normalized to 1)
+- Return nan as importance values if variance is 0. for a hyperparameter / budget
+
 # Version 1.2
 
 ## Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Increase plot font sizes.
 
 ## Bug-Fixes
-- Quantify LPI importance via variance instead of importance over mean (not normalized to 1)
-- Return nan as importance values if variance is 0. for a hyperparameter / budget
+- Quantify LPI importance via variance instead of importance over mean (#152)
+- Return nan as importance values if variance is 0. for a hyperparameter / budget (#152)
 
 # Version 1.2
 

--- a/deepcave/evaluators/fanova.py
+++ b/deepcave/evaluators/fanova.py
@@ -20,6 +20,7 @@ from deepcave.constants import COMBINED_COST_NAME
 from deepcave.evaluators.epm.fanova_forest import FanovaForest
 from deepcave.runs import AbstractRun
 from deepcave.runs.objective import Objective
+from deepcave.utils.logs import get_logger
 
 
 class fANOVA:
@@ -50,6 +51,7 @@ class fANOVA:
         self.cs = run.configspace
         self.hps = self.cs.get_hyperparameters()
         self.hp_names = self.cs.get_hyperparameter_names()
+        self.logger = get_logger(self.__class__.__name__)
 
     def calculate(
         self,
@@ -152,7 +154,14 @@ class fANOVA:
                 )
 
                 if len(non_zero_idx[0]) == 0:
-                    raise RuntimeError("Encountered zero total variance in all trees.")
+                    self.logger.warning("Encountered zero total variance in all trees.")
+                    importances[sub_hp_ids] = (
+                        np.nan,
+                        np.nan,
+                        np.nan,
+                        np.nan,
+                    )
+                    continue
 
                 fractions_total = np.array(
                     [

--- a/deepcave/evaluators/lpi.py
+++ b/deepcave/evaluators/lpi.py
@@ -257,11 +257,11 @@ class LPI:
             std = 0
 
             if hp_name in self.importances:
-                mean = self.importances[hp_name][0]
+                mean = np.mean(self.variances[hp_name])
                 std = np.var(self.variances[hp_name])
 
-            # Use this to quantify importance via variance
-            # mean = np.mean(overall_var_per_tree[hp_name])
+            # Use this to quantify importance via importance over mean value (not normalized to 1)
+            # mean = self.importances[hp_name][0]
 
             # Sometimes there is an ugly effect if default is better than
             # incumbent.

--- a/deepcave/evaluators/lpi.py
+++ b/deepcave/evaluators/lpi.py
@@ -220,7 +220,10 @@ class LPI:
 
         # Normalize
         overall_var_per_tree = {
-            p: [t / sum_var_per_tree[idx] for idx, t in enumerate(trees)]
+            p: [
+                t / sum_var_per_tree[idx] if sum_var_per_tree[idx] != 0.0 else np.nan
+                for idx, t in enumerate(trees)
+            ]
             for p, trees in overall_var_per_tree.items()
         }
         self.variances = overall_var_per_tree

--- a/deepcave/plugins/hyperparameter/importances.py
+++ b/deepcave/plugins/hyperparameter/importances.py
@@ -27,8 +27,11 @@ from deepcave.plugins.static import StaticPlugin
 from deepcave.runs import AbstractRun
 from deepcave.utils.cast import optional_int
 from deepcave.utils.layout import get_checklist_options, get_select_options, help_button
+from deepcave.utils.logs import get_logger
 from deepcave.utils.styled_plot import plt
 from deepcave.utils.styled_plotty import get_color, save_image
+
+logger = get_logger(__name__)
 
 
 class Importances(StaticPlugin):
@@ -337,6 +340,8 @@ class Importances(StaticPlugin):
             evaluator.calculate(objective, budget, n_trees=n_trees, seed=0)
 
             importances = evaluator.get_importances(hp_names)
+            if any(np.isnan(val) for value in importances.values() for val in value):
+                logger.warning(f"Nan encountered in importance values for budget {budget}.")
             data[budget_id] = importances
 
         return data  # type: ignore


### PR DESCRIPTION
- Switch back to quantifying LPI via variance instead of importance over mean value (which is not normalized to 1)
- If there is only one trial for a budget, fANOVA and LPI break as variance is 0., add a workaround that returns nan as importance values in this case

Should fix #152