### PR TITLE
Fix/remove objective merging from plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Use highest budget as default budget for Cost over Time instead of Combined.
 - Show best value / config for each objective instead of merged objective in Overview (#159).
 - Use chosen objective instead of merged objective to get the incumbent for the calculation of LPI importance (#159).
+- Add total runtime in overview (#155).
 
 # Version 1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 - Runs now get displayed with their parent directory for better distinguishability.
 - Increase plot font sizes.
 - Add a simple loading bar functionality for longer runs.
-- Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
-- Use highest budget as default budget for Cost over Time instead of Combined.
 
 ## General
 - Seed is now required in the Recorder.
@@ -13,6 +11,11 @@
 ## Bug-Fixes
 - Use normalized LPI importance via variance instead of importance over mean (#152)
 - Return nan as importance values if variance is 0. for a hyperparameter / budget (#152)
+
+## Plugins
+- Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
+- Use highest budget as default budget for Cost over Time instead of Combined.
+- Show best value / config for each objective instead of merged objective in Overview (#159)
 
 # Version 1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 ## Plugins
 - Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
 - Use highest budget as default budget for Cost over Time instead of Combined.
-- Show best value / config for each objective instead of merged objective in Overview (#159)
+- Show best value / config for each objective instead of merged objective in Overview (#159).
+- Use chosen objective instead of merged objective to get the incumbent for the calculation of LPI importance (#159).
 
 # Version 1.2
 

--- a/deepcave/evaluators/lpi.py
+++ b/deepcave/evaluators/lpi.py
@@ -95,7 +95,7 @@ class LPI:
 
         # Set variables
         self.continous_neighbors = continous_neighbors
-        self.incumbent, _ = self.run.get_incumbent(budget=budget)
+        self.incumbent, _ = self.run.get_incumbent(budget=budget, objectives=objectives)
         self.default = self.cs.get_default_configuration()
         self.incumbent_array = self.incumbent.get_array()
 

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -37,7 +37,7 @@ from deepcave.runs.group import Group
 from deepcave.runs.status import Status
 from deepcave.utils.layout import create_table, help_button
 from deepcave.utils.styled_plotty import get_discrete_heatmap, save_image
-from deepcave.utils.util import get_latest_change
+from deepcave.utils.util import custom_round, get_latest_change
 
 
 class Overview(DynamicPlugin):
@@ -131,22 +131,38 @@ class Overview(DynamicPlugin):
         List[Any]
             A list of the created tables of the overview.
         """
-        # Get best cost across all objectives, highest budget
-        incumbent, _ = run.get_incumbent(statuses=[Status.SUCCESS])
-        config_id = run.get_config_id(incumbent)
-        objective_names = run.get_objective_names()
-
-        avg_costs, std_costs = run.get_avg_costs(config_id)
-
-        best_performances = []
-        for idx in range(len(objective_names)):
-            best_performances += [
-                f"{round(avg_costs[idx], 2)} ± {round(std_costs[idx], 2)} ({objective_names[idx]})"
-            ]
-
         optimizer = run.prefix
         if isinstance(run, Group):
             optimizer = run.get_runs()[0].prefix
+
+        performance_outputs = []
+        for idx, obj in enumerate(run.get_objectives()):
+            # Get best cost for the objective, highest budget
+            incumbent, _ = run.get_incumbent(objectives=obj, statuses=[Status.SUCCESS])
+            config_id = run.get_config_id(incumbent)
+            avg_costs, std_costs = run.get_avg_costs(config_id)
+
+            if len(run.get_seeds(include_combined=False)) > 1:
+                best_performance = (
+                    f"{custom_round(avg_costs[idx])} "
+                    f"± {custom_round(std_costs[idx])} ({obj.name})"
+                )
+            else:
+                best_performance = f"{custom_round(avg_costs[idx])} ({obj.name})"
+
+            performance_outputs.append(
+                html.Div(
+                    [
+                        html.Span(f"Best {obj.name}: {best_performance} "),
+                        html.A(
+                            "(See Configuration)",
+                            href=Configurations.get_link(run, config_id),
+                            style={"color": "white"},
+                        ),
+                    ],
+                    className="card-text",
+                ),
+            )
 
         # Design card for quick information here
         card = dbc.Card(
@@ -162,19 +178,7 @@ class Overview(DynamicPlugin):
                             f"Latest change: {get_latest_change(run.latest_change)}",
                             className="card-text",
                         ),
-                        html.Div(
-                            [
-                                html.Span(
-                                    f"Best average performance: {', '.join(best_performances)} "
-                                ),
-                                html.A(
-                                    "(See Configuration)",
-                                    href=Configurations.get_link(run, config_id),
-                                    style={"color": "white"},
-                                ),
-                            ],
-                            className="card-text",
-                        ),
+                        *performance_outputs,
                         html.Div(
                             [
                                 html.Span(f"Total configurations: {run.get_num_configs()}"),

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -144,11 +144,10 @@ class Overview(DynamicPlugin):
 
             if len(run.get_seeds(include_combined=False)) > 1:
                 best_performance = (
-                    f"{custom_round(avg_costs[idx])} "
-                    f"± {custom_round(std_costs[idx])} ({obj.name})"
+                    f"{custom_round(avg_costs[idx])} " f"± {custom_round(std_costs[idx])}"
                 )
             else:
-                best_performance = f"{custom_round(avg_costs[idx])} ({obj.name})"
+                best_performance = f"{custom_round(avg_costs[idx])}"
 
             performance_outputs.append(
                 html.Div(

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -180,6 +180,15 @@ class Overview(DynamicPlugin):
                         *performance_outputs,
                         html.Div(
                             [
+                                html.Span(
+                                    f"Total runtime [s]: "
+                                    f"{max(trial.end_time for trial in run.history)}"
+                                ),
+                            ],
+                            className="card-text",
+                        ),
+                        html.Div(
+                            [
                                 html.Span(f"Total configurations: {run.get_num_configs()}"),
                             ],
                             className="card-text",

--- a/deepcave/utils/util.py
+++ b/deepcave/utils/util.py
@@ -145,3 +145,25 @@ def print_progress_bar(
 
     if iteration == total:
         print()
+
+
+def custom_round(number: float, min_decimals: int = 2, max_decimals: int = 10) -> float:
+    """
+    Round a number to the nearest decimal.
+
+    Parameters
+    ----------
+    number : float
+        The number to round.
+    min_decimals : int
+        The minimum number of decimals.
+        Default is 2.
+    max_decimals : int
+        The maximum number of decimals.
+        Default is 10.
+    """
+    for i in range(min_decimals, max_decimals + 1):
+        rounded = round(number, i)
+        if rounded != round(number, i - 1):
+            return rounded
+    return round(number, max_decimals)

--- a/deepcave/utils/util.py
+++ b/deepcave/utils/util.py
@@ -147,7 +147,7 @@ def print_progress_bar(
         print()
 
 
-def custom_round(number: float, min_decimals: int = 2, max_decimals: int = 10) -> float:
+def custom_round(number: float, min_decimals: int = 3, max_decimals: int = 10) -> float:
     """
     Round a number to the nearest decimal.
 


### PR DESCRIPTION
- Show best value / config for each objective instead of merged objective in Overview (#159).
- Use chosen objective instead of merged objective to get the incumbent for the calculation of LPI importance (#159).
- Add total runtime in overview (#155).