### PR TITLE
Version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 - Runs now get displayed with their parent directory for better distinguishability.
 - Increase plot font sizes.
 - Add a simple loading bar functionality for longer runs.
-- Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
-- Use highest budget as default budget for Cost over Time instead of Combined.
 
 ## General
 - Seed is now required in the Recorder.
@@ -13,6 +11,13 @@
 ## Bug-Fixes
 - Use normalized LPI importance via variance instead of importance over mean (#152)
 - Return nan as importance values if variance is 0. for a hyperparameter / budget (#152)
+
+## Plugins
+- Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
+- Use highest budget as default budget for Cost over Time instead of Combined.
+- Show best value / config for each objective instead of merged objective in Overview (#159).
+- Use chosen objective instead of merged objective to get the incumbent for the calculation of LPI importance (#159).
+- Add total runtime in overview (#155).
 
 # Version 1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Version 1.2.1
 
 ## Quality of Life
-- Runs now get displayed witn their parent directory for better distinguishability
+- Runs now get displayed with their parent directory for better distinguishability
+- Increase plot font sizes.
 
 # Version 1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Version 1.2.1
 
 ## Quality of Life
-- Runs now get displayed with their parent directory for better distinguishability
+- Runs now get displayed with their parent directory for better distinguishability.
 - Increase plot font sizes.
 - Add a simple loading bar functionality for longer runs.
+- Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
+- Use highest budget as default budget for Cost over Time instead of Combined.
 
 ## General
 - Seed is now required in the Recorder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 ## General
 - Seed is now required in the Recorder.
 
+## Bug-Fixes
+- Use normalized LPI importance via variance instead of importance over mean (#152)
+- Return nan as importance values if variance is 0. for a hyperparameter / budget (#152)
+
 # Version 1.2
 
 ## Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.2.1
+
+## Quality of Life
+- Runs now get displayed witn their parent directory for better distinguishability
+
 # Version 1.2
 
 ## Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Quality of Life
 - Runs now get displayed with their parent directory for better distinguishability
 - Increase plot font sizes.
+- Add a simple loading bar functionality for longer runs.
+
+## General
+- Seed is now required in the Recorder.
 
 # Version 1.2
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # are usually completed in github actions.
 
 SHELL := /bin/bash
-VERSION := 1.2
+VERSION := 1.2.1
 
 NAME := DeepCAVE
 PACKAGE_NAME := deepcave
@@ -48,10 +48,10 @@ install:
 install-dev:
 	$(PIP) install -e ".[dev]"
 	pre-commit install
-	
+
 install-examples:
 	$(PIP) install -e ".[examples]"
-	
+
 check-black:
 	$(BLACK) ${SOURCE_DIR} --check || :
 	$(BLACK) ${EXAMPLES_DIR} --check || :
@@ -123,7 +123,7 @@ publish: clean build
 	$(PYTHON) -m twine upload --repository testpypi ${DIST}/*
 	@echo
 	@echo "Test with the following:"
-	@echo "* Create a new virtual environment to install the uplaoded distribution into"
+	@echo "* Create a new virtual environment to install the uploaded distribution into"
 	@echo "* Run the following:"
 	@echo "--- pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ${PACKAGE_NAME}==${VERSION}"
 	@echo

--- a/deepcave/__init__.py
+++ b/deepcave/__init__.py
@@ -26,7 +26,7 @@ project_urls = {
     "Source Code": "https://github.com/automl/deepcave",
 }
 copyright = f"Copyright {datetime.date.today().strftime('%Y')}, {author}"
-version = "1.2"
+version = "1.2.1"
 
 _exec_file = sys.argv[0]
 _exec_files = ["server.py", "worker.py", "sphinx-build"]

--- a/deepcave/config.py
+++ b/deepcave/config.py
@@ -57,6 +57,7 @@ class Config:
     FIGURE_MARGIN = dict(t=30, b=0, l=0, r=0)
     FIGURE_HEIGHT = "40vh"
     FIGURE_DOWNLOAD_SCALE = 4.0
+    FIGURE_FONT_SIZE = 20
 
     # Redis settings
     REDIS_PORT: int = 6379

--- a/deepcave/evaluators/fanova.py
+++ b/deepcave/evaluators/fanova.py
@@ -20,6 +20,7 @@ from deepcave.constants import COMBINED_COST_NAME
 from deepcave.evaluators.epm.fanova_forest import FanovaForest
 from deepcave.runs import AbstractRun
 from deepcave.runs.objective import Objective
+from deepcave.utils.logs import get_logger
 
 
 class fANOVA:
@@ -50,6 +51,7 @@ class fANOVA:
         self.cs = run.configspace
         self.hps = self.cs.get_hyperparameters()
         self.hp_names = self.cs.get_hyperparameter_names()
+        self.logger = get_logger(self.__class__.__name__)
 
     def calculate(
         self,
@@ -152,7 +154,14 @@ class fANOVA:
                 )
 
                 if len(non_zero_idx[0]) == 0:
-                    raise RuntimeError("Encountered zero total variance in all trees.")
+                    self.logger.warning("Encountered zero total variance in all trees.")
+                    importances[sub_hp_ids] = (
+                        np.nan,
+                        np.nan,
+                        np.nan,
+                        np.nan,
+                    )
+                    continue
 
                 fractions_total = np.array(
                     [

--- a/deepcave/evaluators/lpi.py
+++ b/deepcave/evaluators/lpi.py
@@ -220,7 +220,10 @@ class LPI:
 
         # Normalize
         overall_var_per_tree = {
-            p: [t / sum_var_per_tree[idx] for idx, t in enumerate(trees)]
+            p: [
+                t / sum_var_per_tree[idx] if sum_var_per_tree[idx] != 0.0 else np.nan
+                for idx, t in enumerate(trees)
+            ]
             for p, trees in overall_var_per_tree.items()
         }
         self.variances = overall_var_per_tree
@@ -254,11 +257,11 @@ class LPI:
             std = 0
 
             if hp_name in self.importances:
-                mean = self.importances[hp_name][0]
+                mean = np.mean(self.variances[hp_name])
                 std = np.var(self.variances[hp_name])
 
-            # Use this to quantify importance via variance
-            # mean = np.mean(overall_var_per_tree[hp_name])
+            # Use this to quantify importance via importance over mean value (not normalized to 1)
+            # mean = self.importances[hp_name][0]
 
             # Sometimes there is an ugly effect if default is better than
             # incumbent.

--- a/deepcave/evaluators/lpi.py
+++ b/deepcave/evaluators/lpi.py
@@ -95,7 +95,7 @@ class LPI:
 
         # Set variables
         self.continous_neighbors = continous_neighbors
-        self.incumbent, _ = self.run.get_incumbent(budget=budget)
+        self.incumbent, _ = self.run.get_incumbent(budget=budget, objectives=objectives)
         self.default = self.cs.get_default_configuration()
         self.incumbent_array = self.incumbent.get_array()
 

--- a/deepcave/plugins/__init__.py
+++ b/deepcave/plugins/__init__.py
@@ -1145,8 +1145,12 @@ class Plugin(Layout, ABC):
         for run in runs:
             if check_run_compatibility(run):
                 try:
+                    run_path = run.path
+                    if run_path is not None:
+                        run_name = run_path.parent.name + "/" + run.name
+
                     values.append(run.id)
-                    labels.append(run.name)
+                    labels.append(run_name)
                     disabled.append(False)
                 except Exception:
                     pass

--- a/deepcave/plugins/budget/budget_correlation.py
+++ b/deepcave/plugins/budget/budget_correlation.py
@@ -311,6 +311,7 @@ class BudgetCorrelation(DynamicPlugin):
             yaxis=dict(title="Correlation"),
             margin=config.FIGURE_MARGIN,
             legend=dict(title="Budgets"),
+            font=dict(size=config.FIGURE_FONT_SIZE),
         )
 
         figure = go.Figure(data=traces, layout=layout)

--- a/deepcave/plugins/hyperparameter/importances.py
+++ b/deepcave/plugins/hyperparameter/importances.py
@@ -27,8 +27,11 @@ from deepcave.plugins.static import StaticPlugin
 from deepcave.runs import AbstractRun
 from deepcave.utils.cast import optional_int
 from deepcave.utils.layout import get_checklist_options, get_select_options, help_button
+from deepcave.utils.logs import get_logger
 from deepcave.utils.styled_plot import plt
 from deepcave.utils.styled_plotty import get_color, save_image
+
+logger = get_logger(__name__)
 
 
 class Importances(StaticPlugin):
@@ -337,6 +340,8 @@ class Importances(StaticPlugin):
             evaluator.calculate(objective, budget, n_trees=n_trees, seed=0)
 
             importances = evaluator.get_importances(hp_names)
+            if any(np.isnan(val) for value in importances.values() for val in value):
+                logger.warning(f"Nan encountered in importance values for budget {budget}.")
             data[budget_id] = importances
 
         return data  # type: ignore

--- a/deepcave/plugins/hyperparameter/importances.py
+++ b/deepcave/plugins/hyperparameter/importances.py
@@ -458,6 +458,7 @@ class Importances(StaticPlugin):
             legend={"title": "Budget"},
             margin=config.FIGURE_MARGIN,
             xaxis=dict(tickangle=-45),
+            font=dict(size=config.FIGURE_FONT_SIZE),
         )
         save_image(figure, "importances.pdf")
 

--- a/deepcave/plugins/hyperparameter/pdp.py
+++ b/deepcave/plugins/hyperparameter/pdp.py
@@ -374,7 +374,7 @@ class PartialDependencies(StaticPlugin):
 
     @staticmethod
     def get_pdp_figure(  # type: ignore
-        run, inputs, outputs, show_confidence, show_ice, title=None
+        run, inputs, outputs, show_confidence, show_ice, title=None, fontsize=None
     ) -> go.Figure:
         """
         Create a figure of the Partial Dependency Plot (PDP).
@@ -393,6 +393,8 @@ class PartialDependencies(StaticPlugin):
             Whether to show ice curves in the plot.
         title
             Title of the plot.
+        fontsize
+            Fontsize of the plot.
 
         Returns
         -------
@@ -471,6 +473,9 @@ class PartialDependencies(StaticPlugin):
             ]
 
             tickvals, ticktext = get_hyperparameter_ticks(hp1)
+            # Allow to pass a fontsize (necessary when leveraging PDP in Symbolic Explanation)
+            if fontsize is None:
+                fontsize = config.FIGURE_FONT_SIZE
             layout = go.Layout(
                 {
                     "xaxis": {
@@ -482,6 +487,7 @@ class PartialDependencies(StaticPlugin):
                         "title": objective_name,
                     },
                     "title": title,
+                    "font": dict(size=fontsize),
                 }
             )
         else:
@@ -509,6 +515,7 @@ class PartialDependencies(StaticPlugin):
                     yaxis=dict(tickvals=y_tickvals, ticktext=y_ticktext, title=hp2_name),
                     margin=config.FIGURE_MARGIN,
                     title=title,
+                    font=dict(size=fontsize),
                 )
             )
 

--- a/deepcave/plugins/hyperparameter/symbolic_explanations.py
+++ b/deepcave/plugins/hyperparameter/symbolic_explanations.py
@@ -577,6 +577,7 @@ class SymbolicExplanations(StaticPlugin):
                         "title": objective_name,
                     },
                     "title": expr,
+                    "font": dict(size=config.FIGURE_FONT_SIZE - 4),
                 }
             )
         else:
@@ -602,6 +603,7 @@ class SymbolicExplanations(StaticPlugin):
                     yaxis=dict(tickvals=y_tickvals, ticktext=y_ticktext, title=hp2_name),
                     margin=config.FIGURE_MARGIN,
                     title=expr,
+                    font=dict(size=config.FIGURE_FONT_SIZE - 4),
                 )
             )
 
@@ -614,7 +616,13 @@ class SymbolicExplanations(StaticPlugin):
             pdp_title = "Partial Dependency for comparison:"
 
         figure2 = PartialDependencies.get_pdp_figure(
-            run, inputs, outputs, show_confidence=False, show_ice=False, title=pdp_title
+            run,
+            inputs,
+            outputs,
+            show_confidence=False,
+            show_ice=False,
+            title=pdp_title,
+            fontsize=config.FIGURE_FONT_SIZE - 4,
         )
 
         return [figure1, figure2]

--- a/deepcave/plugins/objective/configuration_cube.py
+++ b/deepcave/plugins/objective/configuration_cube.py
@@ -416,7 +416,10 @@ class ConfigurationCube(DynamicPlugin):
 
         if len(data) == 3:
             trace = go.Scatter3d(x=x, y=y, z=z, **scatter_kwargs)
-            layout = go.Layout({"scene": {**layout_kwargs}})
+            layout = go.Layout(
+                {"scene": {**layout_kwargs}},
+                font=dict(size=config.FIGURE_FONT_SIZE),
+            )
         else:
             if len(data) == 1:
                 y = [0 for _ in x]
@@ -425,7 +428,10 @@ class ConfigurationCube(DynamicPlugin):
                 trace = go.Scatter(x=x, y=y, **scatter_kwargs)
             else:
                 trace = go.Scatter(x=[], y=[])
-            layout = go.Layout(**layout_kwargs)
+            layout = go.Layout(
+                **layout_kwargs,
+                font=dict(size=config.FIGURE_FONT_SIZE),
+            )
 
         figure = go.Figure(data=trace, layout=layout)
         figure.update_layout(dict(margin=config.FIGURE_MARGIN))

--- a/deepcave/plugins/objective/cost_over_time.py
+++ b/deepcave/plugins/objective/cost_over_time.py
@@ -225,7 +225,9 @@ class CostOverTime(DynamicPlugin):
             },
             "budget_id": {
                 "options": self.budget_options,
-                "value": self.budget_options[-1]["value"],
+                "value": self.budget_options[0]["value"]
+                if len(self.budget_options) == 1
+                else self.budget_options[-2]["value"],
             },
             "xaxis": {
                 "options": [
@@ -344,8 +346,7 @@ class CostOverTime(DynamicPlugin):
                 continue
 
             objective = run.get_objective(inputs["objective_id"])
-            budget = run.get_budget(inputs["budget_id"])
-            config_ids = outputs[run.id]["config_ids"]
+            ids = outputs[run.id]["ids"]
             x = outputs[run.id]["times"]
             if inputs["xaxis"] == "trials":
                 x = outputs[run.id]["ids"]
@@ -360,9 +361,11 @@ class CostOverTime(DynamicPlugin):
             hoverinfo = "skip"
             symbol = None
             mode = "lines"
-            if len(config_ids) > 0:
+            if len(run.history) > 0:
                 hovertext = [
-                    get_hovertext_from_config(run, config_id, budget) for config_id in config_ids
+                    get_hovertext_from_config(run, trial.config_id, trial.budget)
+                    for id, trial in enumerate(run.history)
+                    if id in ids
                 ]
                 hoverinfo = "text"
                 symbol = "circle"

--- a/deepcave/plugins/objective/cost_over_time.py
+++ b/deepcave/plugins/objective/cost_over_time.py
@@ -423,6 +423,7 @@ class CostOverTime(DynamicPlugin):
             xaxis=dict(title=xaxis_label, type=type),
             yaxis=dict(title=objective.name),
             margin=config.FIGURE_MARGIN,
+            font=dict(size=config.FIGURE_FONT_SIZE),
         )
 
         figure = go.Figure(data=traces, layout=layout)

--- a/deepcave/plugins/objective/parallel_coordinates.py
+++ b/deepcave/plugins/objective/parallel_coordinates.py
@@ -421,7 +421,10 @@ class ParallelCoordinates(StaticPlugin):
                 dimensions=list([d for d in data.values()]),
                 labelangle=45,
             ),
-            layout=dict(margin=dict(t=150, b=50, l=100, r=0)),
+            layout=dict(
+                margin=dict(t=150, b=50, l=100, r=0),
+                font=dict(size=config.FIGURE_FONT_SIZE),
+            ),
         )
         save_image(figure, "parallel_coordinates.pdf")
 

--- a/deepcave/plugins/objective/pareto_front.py
+++ b/deepcave/plugins/objective/pareto_front.py
@@ -446,7 +446,7 @@ class ParetoFront(DynamicPlugin):
                     x_std += [points_std[point_idx][0]]
                     y_std += [points_std[point_idx][1]]
 
-            color = get_color(idx, alpha=0.1)
+            color = get_color(idx, alpha=0.5)
             color_pareto = get_color(idx)
 
             if show_all:
@@ -524,6 +524,7 @@ class ParetoFront(DynamicPlugin):
                 xaxis=dict(title=objective_1.name),
                 yaxis=dict(title=objective_2.name),
                 margin=config.FIGURE_MARGIN,
+                font=dict(size=config.FIGURE_FONT_SIZE),
             )
         else:
             layout = None
@@ -605,12 +606,11 @@ class ParetoFront(DynamicPlugin):
                     x += [points[point_idx][0]]
                     y += [points[point_idx][1]]
 
-            # , alpha=0.1)
             color = plt.get_color(idx)  # type: ignore
             color_pareto = plt.get_color(idx)  # type: ignore
 
             if show_all:
-                plt.scatter(x, y, color=color, marker="o", alpha=0.1, s=3)
+                plt.scatter(x, y, color=color, marker="o", s=3)
 
             # Check if hv or vh is needed
             objective_1 = run.get_objective(inputs["objective_id_1"])

--- a/deepcave/plugins/summary/configurations.py
+++ b/deepcave/plugins/summary/configurations.py
@@ -418,7 +418,10 @@ class Configurations(DynamicPlugin):
                     }
                 )
 
-        objective_layout = go.Layout(**layout_kwargs)
+        objective_layout = go.Layout(
+            **layout_kwargs,
+            font=dict(size=config.FIGURE_FONT_SIZE),
+        )
         objective_figure = go.Figure(data=objective_data, layout=objective_layout)
         save_image(objective_figure, "configure.pdf")
 
@@ -480,7 +483,8 @@ class Configurations(DynamicPlugin):
                 margin=dict(
                     t=150,
                     b=50,
-                )
+                ),
+                font=dict(size=config.FIGURE_FONT_SIZE),
             ),
         )
 

--- a/deepcave/plugins/summary/footprint.py
+++ b/deepcave/plugins/summary/footprint.py
@@ -353,6 +353,7 @@ class FootPrint(StaticPlugin):
             zsmooth="best",
             hoverinfo="skip",
             colorbar=dict(
+                y=0.4,
                 len=0.5,
                 title=objective.name,
             ),
@@ -392,10 +393,10 @@ class FootPrint(StaticPlugin):
         # Now add the points
         for name, points, color_id in zip(point_names, point_values, point_color_ids):
             x, y, config_ids = outputs[points]
-            size = 5
+            size = 8
             marker_symbol = "x"
             if points == "incumbent_points":
-                size = 10
+                size = 14
                 marker_symbol = "triangle-up"
             traces += [
                 go.Scatter(
@@ -417,6 +418,7 @@ class FootPrint(StaticPlugin):
             xaxis=dict(title=None, tickvals=[]),
             yaxis=dict(title=None, tickvals=[]),
             margin=config.FIGURE_MARGIN,
+            font=dict(size=config.FIGURE_FONT_SIZE),
         )
 
         performance = go.Figure(data=[performance_data] + traces, layout=layout)
@@ -520,10 +522,10 @@ class FootPrint(StaticPlugin):
             # Now add the points
             for name, points, color_id in zip(point_names, point_values, point_color_ids):
                 x, y, _ = outputs[points]
-                size = 3
+                size = 8
                 marker_symbol = "X"
                 if points == "incumbent_points":
-                    size = 10
+                    size = 14
                     marker_symbol = "^"
 
                 color = plt.get_color(color_id)  # type: ignore

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -402,6 +402,7 @@ class Overview(DynamicPlugin):
             xaxis=dict(title="Status"),
             yaxis=dict(title="Number of configurations"),
             margin=config.FIGURE_MARGIN,
+            font=dict(size=config.FIGURE_FONT_SIZE),
         )
         stats_figure = go.Figure(data=stats_data, layout=stats_layout)
         save_image(stats_figure, "status_bar.pdf")
@@ -411,6 +412,7 @@ class Overview(DynamicPlugin):
             xaxis=dict(title="Budget (Seed)"),
             yaxis=dict(title="Configuration ID"),
             margin=config.FIGURE_MARGIN,
+            font=dict(size=config.FIGURE_FONT_SIZE),
         )
         config_figure = go.Figure(
             data=get_discrete_heatmap(

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -163,6 +163,11 @@ class Overview(DynamicPlugin):
                 ),
             )
 
+        if isinstance(run, Group):
+            runtime_str = "Maximum runtime"
+        else:
+            runtime_str = "Total runtime"
+
         # Design card for quick information here
         card = dbc.Card(
             [
@@ -181,7 +186,7 @@ class Overview(DynamicPlugin):
                         html.Div(
                             [
                                 html.Span(
-                                    f"Total runtime [s]: "
+                                    f"{runtime_str} [s]: "
                                     f"{max(trial.end_time for trial in run.history)}"
                                 ),
                             ],

--- a/deepcave/plugins/summary/overview.py
+++ b/deepcave/plugins/summary/overview.py
@@ -37,7 +37,7 @@ from deepcave.runs.group import Group
 from deepcave.runs.status import Status
 from deepcave.utils.layout import create_table, help_button
 from deepcave.utils.styled_plotty import get_discrete_heatmap, save_image
-from deepcave.utils.util import get_latest_change
+from deepcave.utils.util import custom_round, get_latest_change
 
 
 class Overview(DynamicPlugin):
@@ -131,22 +131,37 @@ class Overview(DynamicPlugin):
         List[Any]
             A list of the created tables of the overview.
         """
-        # Get best cost across all objectives, highest budget
-        incumbent, _ = run.get_incumbent(statuses=[Status.SUCCESS])
-        config_id = run.get_config_id(incumbent)
-        objective_names = run.get_objective_names()
-
-        avg_costs, std_costs = run.get_avg_costs(config_id)
-
-        best_performances = []
-        for idx in range(len(objective_names)):
-            best_performances += [
-                f"{round(avg_costs[idx], 2)} ± {round(std_costs[idx], 2)} ({objective_names[idx]})"
-            ]
-
         optimizer = run.prefix
         if isinstance(run, Group):
             optimizer = run.get_runs()[0].prefix
+
+        performance_outputs = []
+        for idx, obj in enumerate(run.get_objectives()):
+            # Get best cost for the objective, highest budget
+            incumbent, _ = run.get_incumbent(objectives=obj, statuses=[Status.SUCCESS])
+            config_id = run.get_config_id(incumbent)
+            avg_costs, std_costs = run.get_avg_costs(config_id)
+
+            if len(run.get_seeds(include_combined=False)) > 1:
+                best_performance = (
+                    f"{custom_round(avg_costs[idx])} " f"± {custom_round(std_costs[idx])}"
+                )
+            else:
+                best_performance = f"{custom_round(avg_costs[idx])}"
+
+            performance_outputs.append(
+                html.Div(
+                    [
+                        html.Span(f"Best {obj.name}: {best_performance} "),
+                        html.A(
+                            "(See Configuration)",
+                            href=Configurations.get_link(run, config_id),
+                            style={"color": "white"},
+                        ),
+                    ],
+                    className="card-text",
+                ),
+            )
 
         # Design card for quick information here
         card = dbc.Card(
@@ -162,15 +177,12 @@ class Overview(DynamicPlugin):
                             f"Latest change: {get_latest_change(run.latest_change)}",
                             className="card-text",
                         ),
+                        *performance_outputs,
                         html.Div(
                             [
                                 html.Span(
-                                    f"Best average performance: {', '.join(best_performances)} "
-                                ),
-                                html.A(
-                                    "(See Configuration)",
-                                    href=Configurations.get_link(run, config_id),
-                                    style={"color": "white"},
+                                    f"Total runtime [s]: "
+                                    f"{max(trial.end_time for trial in run.history)}"
                                 ),
                             ],
                             className="card-text",

--- a/deepcave/runs/__init__.py
+++ b/deepcave/runs/__init__.py
@@ -754,15 +754,15 @@ class AbstractRun(ABC):
         ----------
         budget : Optional[Union[int, float]]
             Budget to select the costs. If no budget is given, the highest budget is chosen.
-            By default None.
+            By default, None.
         statuses : Optional[Union[Status, List[Status]]]
             Only selected stati are considered. If no status is given, all stati are considered.
-            By default None.
+            By default, None.
         seed : Optional[int], optional
             Seed to select the costs. If no seed is given, all seeds are considered.
-            By default None.
+            By default, None.
         selected_ids: Optional[List[int]], optional
-            If set, only history ids in the list will be considered. By default None.
+            If set, only history ids in the list will be considered. By default, None.
 
         Returns
         -------

--- a/deepcave/runs/recorder.py
+++ b/deepcave/runs/recorder.py
@@ -86,7 +86,7 @@ class Recorder:
 
         # Set variables
         self.last_trial_id: Optional[
-            Tuple[Union[Dict[Any, Any], Configuration], Optional[float], Optional[int]]
+            Tuple[Union[Dict[Any, Any], Configuration], Optional[float], int]
         ] = None
         self.start_time = time.time()
         self.start_times: Dict[
@@ -158,7 +158,7 @@ class Recorder:
         self,
         config: Configuration,
         budget: Optional[float] = None,
-        seed: Optional[int] = None,
+        seed: int = -1,
         model: Optional[Any] = None,
         origin: Optional[str] = None,
         additional: Optional[dict] = None,
@@ -174,9 +174,9 @@ class Recorder:
         budget : Optional[float], optional
             The budget.
             Default is None.
-        seed : Optional[int], optional
+        seed : int
             The seed.
-            Default is None.
+            Default is -1.
         model : Optional[Any], optional
             The model used.
             Default is None.
@@ -193,7 +193,7 @@ class Recorder:
         if additional is None:
             additional = {}
 
-        id: Tuple[Union[Dict[Any, Any], Configuration], Optional[float], Optional[int]] = (
+        id: Tuple[Union[Dict[Any, Any], Configuration], Optional[float], int] = (
             config,
             budget,
             seed,
@@ -216,7 +216,7 @@ class Recorder:
         status: Status = Status.SUCCESS,
         config: Optional[Union[dict, Configuration]] = None,
         budget: Optional[float] = np.inf,
-        seed: Optional[int] = -1,
+        seed: int = -1,
         additional: Optional[dict] = None,
         end_time: Optional[float] = None,
     ) -> None:
@@ -241,7 +241,7 @@ class Recorder:
         budget : float, optional
             The budget.
             Default is np.inf.
-        seed : int, optional
+        seed : int
             The seed.
             Default is -1.
         additional : Optional[dict], optional

--- a/deepcave/utils/util.py
+++ b/deepcave/utils/util.py
@@ -145,3 +145,25 @@ def print_progress_bar(
 
     if iteration == total:
         print()
+
+
+def custom_round(number: float, min_decimals: int = 3, max_decimals: int = 10) -> float:
+    """
+    Round a number to the nearest decimal.
+
+    Parameters
+    ----------
+    number : float
+        The number to round.
+    min_decimals : int
+        The minimum number of decimals.
+        Default is 2.
+    max_decimals : int
+        The maximum number of decimals.
+        Default is 10.
+    """
+    for i in range(min_decimals, max_decimals + 1):
+        rounded = round(number, i)
+        if rounded != round(number, i - 1):
+            return rounded
+    return round(number, max_decimals)

--- a/deepcave/utils/util.py
+++ b/deepcave/utils/util.py
@@ -104,3 +104,44 @@ def get_latest_change(st_mtime: int) -> str:
         return f"{d_diff} days ago"
     else:
         return t.strftime("%Y/%m/%d")
+
+
+def print_progress_bar(
+    total: int,
+    iteration: int,
+    prefix: str = "",
+    suffix: str = "",
+    decimals: int = 1,
+    length: int = 100,
+    fill: str = "█",
+    print_end: str = "",
+) -> None:
+    """
+    Print a simple progress bar.
+
+    Parameters
+    ----------
+    total : int
+        The total number of iterations.
+    iteration
+        The current iteration (usually, index+1).
+    prefix
+        String to print before the progress bar.
+    suffix
+        String to print after the progress bar.
+    decimals
+        Number of decimals in the percentage.
+    length
+        The length of the progress bar.
+    fill
+        The character to fill the progress bar with.
+    print_end
+        The character to print at the end of the line.
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+    filled_length = int(length * iteration // total)
+    bar = fill * filled_length + "-" * (length - filled_length)
+    print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=print_end)
+
+    if iteration == total:
+        print()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,11 @@ options = {
         "examples_dirs": "../examples",
         "ignore_pattern": ".*logs$|.*__pycache__$|.*_pending$",
     },
+    "linkcheck_request_headers" : {
+        r'https://docs.github.com/': {
+            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) '
+                          'Gecko/20100101 Firefox/24.0'}
+    }
 }
 
 automl_sphinx_theme.set_options(globals(), options)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,11 +15,6 @@ options = {
         "examples_dirs": "../examples",
         "ignore_pattern": ".*logs$|.*__pycache__$|.*_pending$",
     },
-    "linkcheck_request_headers" : {
-        r'https://docs.github.com/': {
-            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) '
-                          'Gecko/20100101 Firefox/24.0'}
-    }
 }
 
 automl_sphinx_theme.set_options(globals(), options)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,12 +10,12 @@ mode.
     sudo apt-get install redis-server  # Linux
 
 
-.. note:: 
+.. note::
 
     If you have problems see next section for extened instructions.
 
 
-.. warning:: 
+.. warning::
 
     DeepCAVE is tested on Linux and Mac only. Since a bash script is used to start the services
     (redis, workers and webserver), it is not possible to run DeepCAVE on Windows.
@@ -23,7 +23,7 @@ mode.
 
 The following commands install DeepCAVE. We recommend using anaconda as `swig` can be installed
 directly. If you use a different environment, make sure
-`swig <https://www.dev2qa.com/how-to-install-swig-on-macos-linux-and-windows/>`_ is installed.
+`swig <https://www.swig.org/index.html>`_ is installed.
 
 .. code:: bash
 

--- a/examples/record/minimal.py
+++ b/examples/record/minimal.py
@@ -27,6 +27,7 @@ with Recorder(configspace, objectives=[accuracy, time], save_path=save_path) as 
             r.start(config, budget)
 
             # Your code goes here
-            accuracy = np.random.uniform(low=0.0, high=1.0, size=None)
+            accuracy = np.random.uniform(low=0.0, high=1.0)
+            time = np.random.uniform(low=0.0, high=1.0)
 
-            r.end(costs=[accuracy, None])
+            r.end(costs=[accuracy, time], seed=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ setuptools==68.2.2
 absl-py>=1.0.0
 jsonlines>=3.0.0
 pandas>=1.3.4
-numpy>=1.22.2
+numpy==1.26.4
 matplotlib>=3.5.1
 seaborn>=0.13.0
 pyyaml>=6.0.1

--- a/tests/test_evaluators/test_random_forest_surrogate.py
+++ b/tests/test_evaluators/test_random_forest_surrogate.py
@@ -17,7 +17,7 @@ class TestRandomForestSurrogate(unittest.TestCase):
         sampler.sample(100)
 
         # Surrogate
-        self.surrogate = RandomForestSurrogate(self.cs)
+        self.surrogate = RandomForestSurrogate(self.cs, seed=42)
         self.surrogate.fit(sampler.X, sampler.y)
 
     def test_predict_config(self):


### PR DESCRIPTION
# Version 1.2.1

## Quality of Life
- Runs now get displayed with their parent directory for better distinguishability.
- Increase plot font sizes.
- Add a simple loading bar functionality for longer runs.

## General
- Seed is now required in the Recorder.

## Bug-Fixes
- Use normalized LPI importance via variance instead of importance over mean (#152)
- Return nan as importance values if variance is 0. for a hyperparameter / budget (#152)

## Plugins
- Show a run's hoover-text for the actual budget of a trial in Cost over Time with Combined budget (#154).
- Use highest budget as default budget for Cost over Time instead of Combined.
- Show best value / config for each objective instead of merged objective in Overview (#159).
- Use chosen objective instead of merged objective to get the incumbent for the calculation of LPI importance (#159).
- Add total runtime in overview (#155).